### PR TITLE
Fix deployment by specifying assets directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ npm run build
 
 # تشغيل التطبيق
 php artisan serve
+
+# نشر التطبيق
+npm run deploy
 ```
 
 > التطبيق سيكون متاحًا على: `http://localhost:8000`

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "scripts": {
         "dev": "vite",
         "build": "vite build",
-        "build-debug": "vite build --config vite.config.debug.js"
+        "build-debug": "vite build --config vite.config.debug.js",
+        "deploy": "npx wrangler deploy --assets=./public/build"
     },
     "devDependencies": {
         "@popperjs/core": "^2.11.6",

--- a/vite.config.js
+++ b/vite.config.js
@@ -90,4 +90,7 @@ export default defineConfig({
         manifest: true,
         outDir: 'public/build',
     },
+    assets: {
+        directory: 'public/build'
+    }
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,8 @@
+{
+  "name": "worker-name",
+  "compatibility_date": "2025-04-12",
+  "main": "src/index.ts",
+  "assets": {
+    "directory": "./dist"
+  }
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,4 @@
+name = "my-worker"
+main = "dist/index.js"
+compatibility_date = "2025-04-12"
+type = "javascript"


### PR DESCRIPTION
Add deployment configuration for Cloudflare Wrangler.

* **vite.config.js**
  - Add `assets` key to the `defineConfig` object to specify the path to the assets directory.
  - Set the `assets` key to an object with a `directory` property set to `"public/build"`.

* **package.json**
  - Add a new script `"deploy": "npx wrangler deploy --assets=./public/build"` to the `scripts` section.

* **README.md**
  - Add a new step to the installation instructions to run the `npm run deploy` command.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaksws/jak-travel-sys/pull/13?shareId=a03dc929-9f29-47c5-8cc4-6fe17f482941).