### PR TITLE
fix: remove --force option from migration commands in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,10 @@ jobs:
         run: mkdir -p public/storage
 
       - name: Run migrations
-        run: php artisan migrate --force
+        run: php artisan migrate
 
       - name: Create cache table
-        run: php artisan cache:table && php artisan migrate --force
+        run: php artisan cache:table && php artisan migrate
 
       - name: Run custom application status check
         run: php artisan app:check-status

--- a/.github/workflows/debug-build.yml
+++ b/.github/workflows/debug-build.yml
@@ -148,7 +148,7 @@ jobs:
         run: php artisan app:check-status
 
       - name: Run Migrations
-        run: php artisan migrate --force
+        run: php artisan migrate
 
       - name: Seed Database
         run: php artisan db:seed

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,7 @@ jobs:
           fi
 
       - name: Run Migrations
-        run: php artisan migrate --force
+        run: php artisan migrate
 
       - name: Backup Database
         run: php artisan app:database-backup


### PR DESCRIPTION
This pull request makes a minor adjustment to the Laravel migration commands in the GitHub Actions workflow files, removing the `--force` flag from all instances of `php artisan migrate`. This change ensures that migrations will now require explicit confirmation during execution.

### Changes to GitHub Actions workflows:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL42-R45): Removed the `--force` flag from the `php artisan migrate` command in the "Run migrations" and "Create cache table" steps.
* [`.github/workflows/debug-build.yml`](diffhunk://#diff-b56c610ba48c3fbd035bc86528ece8ead2504845de1236adb08c6137b13c4a77L151-R151): Removed the `--force` flag from the `php artisan migrate` command in the "Run Migrations" step.
* [`.github/workflows/tests.yml`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL107-R107): Removed the `--force` flag from the `php artisan migrate` command in the "Run Migrations" step.