### PR TITLE
build(deps): bump league/commonmark from 2.6.2 to 2.7.0 in the compos…

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1584,16 +1584,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.6.2",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "06c3b0bf2540338094575612f4a1778d0d2d5e94"
+                "reference": "6fbb36d44824ed4091adbcf4c7d4a3923cdb3405"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/06c3b0bf2540338094575612f4a1778d0d2d5e94",
-                "reference": "06c3b0bf2540338094575612f4a1778d0d2d5e94",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/6fbb36d44824ed4091adbcf4c7d4a3923cdb3405",
+                "reference": "6fbb36d44824ed4091adbcf4c7d4a3923cdb3405",
                 "shasum": ""
             },
             "require": {
@@ -1630,7 +1630,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.7-dev"
+                    "dev-main": "2.8-dev"
                 }
             },
             "autoload": {
@@ -1687,7 +1687,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-18T21:09:27+00:00"
+            "time": "2025-05-05T12:20:28+00:00"
         },
         {
             "name": "league/config",


### PR DESCRIPTION
…er group (#63)

build(deps): bump league/commonmark in the composer group

Bumps the composer group with 1 update: [league/commonmark](https://github.com/thephpleague/commonmark).


Updates `league/commonmark` from 2.6.2 to 2.7.0
- [Release notes](https://github.com/thephpleague/commonmark/releases)
- [Changelog](https://github.com/thephpleague/commonmark/blob/2.7/CHANGELOG.md)
- [Commits](https://github.com/thephpleague/commonmark/compare/2.6.2...2.7.0)

---
updated-dependencies:
- dependency-name: league/commonmark dependency-version: 2.7.0 dependency-type: indirect dependency-group: composer ...