### PR TITLE
Create jekyll-gh-pages.yml

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,0 +1,51 @@
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the building and deployment of a Jekyll site to GitHub Pages. The workflow is designed to streamline the deployment process with preinstalled dependencies and optimized permissions.

### New GitHub Actions workflow for Jekyll deployment:

* [`.github/workflows/jekyll-gh-pages.yml`](diffhunk://#diff-36a7fe6e9af1fc515ab07c70bee1dd529453c776db13abf7f5c6b2b3b34c4be3R1-R51): Added a workflow that builds and deploys a Jekyll site to GitHub Pages. It includes steps for checking out the repository, configuring Pages, building the site with Jekyll, uploading artifacts, and deploying to GitHub Pages. The workflow supports manual triggers and ensures only one concurrent deployment per group without canceling in-progress runs.